### PR TITLE
Civet setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ $(XOLOTL_DEPEND_LIBS): $(XOLOTL_DIR)/xolotl/xolotlSolver/Solver.cpp
 	cd xolotl; \
 	mkdir build; \
 	cd build; \
-	PETSC_DIR=$(PETSC_DIR) PETSC_ARCH=$(PETSC_ARCH) HDF5_ROOT=$(PETSC_DIR)/$(PETSC_ARCH) \
+	PETSC_DIR=$(PETSC_DIR) PETSC_ARCH=$(PETSC_ARCH) \
 	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=mpicxx \
 	-DBUILD_SHARED_LIBS=yes -DCMAKE_CXX_FLAGS_RELEASE="-o3 -fPIC" ../xolotl; \
 	make; make install \

--- a/test/tests/kernels/2D/param_x2x_2D_noCnoR.txt
+++ b/test/tests/kernels/2D/param_x2x_2D_noCnoR.txt
@@ -1,0 +1,13 @@
+petscArgs=-fieldsplit_1_pc_gamg_threshold -1 -ts_max_steps 1000 -xenon_retention -ts_max_time 2.0e8 -ts_adapt_dt_max 5.0e3 -ts_dt 1.0e-1 -ts_exact_final_time matchstep -fieldsplit_0_pc_type sor -ts_max_snes_failures -1 -pc_fieldsplit_detect_coupling -ts_monitor -pc_type fieldsplit -fieldsplit_1_pc_type gamg -fieldsplit_1_ksp_type gmres -ksp_type fgmres
+vizHandler=dummy
+flux=8.0e-9
+boundary=1 1 1 1 
+netParam=1 0 0 0 0
+grid=63 322.58 63 322.58
+material=Fuel
+dimensions=2
+perfHandler=dummy
+startTemp=1800
+grouping=101 2
+process=diff reaction
+regularGrid=yes


### PR DESCRIPTION
@sblondel I tried to setup civet.

In this PR, I did moose submodule update to point to the latest moose. There was one test failing. Could you check if you have any idea

```
test:kernels/2D.Xolotl_to_xolotl: Working Directory: /home/kongf/workhome/rod/coupling_xolotl/test/tests/kernels/2D
test:kernels/2D.Xolotl_to_xolotl: Running command: /home/kongf/workhome/rod/coupling_xolotl/coupling_xolotl-opt -i x2x_master_2D_noCnoR.i --error-override --no-gdb-backtrace
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: *** Warning, This code is deprecated and will be removed in future versions:
test:kernels/2D.Xolotl_to_xolotl: The parameter 'use_legacy_dirichlet_bc' is no longer valid.
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: All Dirichlet boundary conditions are preset by default.
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: Remove said parameter in main to remove this deprecation warning.
test:kernels/2D.Xolotl_to_xolotl: Stack frames: 12
test:kernels/2D.Xolotl_to_xolotl: 0: libMesh::print_trace(std::ostream&)
test:kernels/2D.Xolotl_to_xolotl: 1: void moose::internal::mooseDeprecatedStream<libMesh::BasicOStreamProxy<char, std::char_traits<char> >, char const (&) [62], char const (&) [59], char const (&) [26], std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const (&) [37]>(libMesh::BasicOStreamProxy<char, std::char_traits<char> >&, bool, char const (&) [62], char const (&) [59], char const (&) [26], std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const (&) [37])
test:kernels/2D.Xolotl_to_xolotl: 2: MooseApp::MooseApp(InputParameters)
test:kernels/2D.Xolotl_to_xolotl: 3: coupling_xolotlApp::coupling_xolotlApp(InputParameters)
test:kernels/2D.Xolotl_to_xolotl: 4: coupling_xolotlTestApp::coupling_xolotlTestApp(InputParameters)
test:kernels/2D.Xolotl_to_xolotl: 5: /home/kongf/workhome/rod/coupling_xolotl/test/lib/libcoupling_xolotl_test-opt.so.0(+0xbfd4) [0x7f67b21b3fd4]
test:kernels/2D.Xolotl_to_xolotl: 6: std::shared_ptr<MooseApp> buildApp<coupling_xolotlTestApp>(InputParameters const&)
test:kernels/2D.Xolotl_to_xolotl: 7: AppFactory::createShared(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, InputParameters, int)
test:kernels/2D.Xolotl_to_xolotl: 8: AppFactory::createAppShared(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, char**, int)
test:kernels/2D.Xolotl_to_xolotl: 9: /home/kongf/workhome/rod/coupling_xolotl/coupling_xolotl-opt() [0x403d6f]
test:kernels/2D.Xolotl_to_xolotl: 10: __libc_start_main
test:kernels/2D.Xolotl_to_xolotl: 11: /home/kongf/workhome/rod/coupling_xolotl/coupling_xolotl-opt() [0x403fce]
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: Starting Xolotl Plasma-Surface Interactions Simulator
test:kernels/2D.Xolotl_to_xolotl: Wed Jun 23 15:48:32 2021
test:kernels/2D.Xolotl_to_xolotl: Options: unable to open parameter file: /home/kongf/workhome/rod/coupling_xolotl/test/tests/kernels/2D/./param_x2x_2D_noCnoR.txt
test:kernels/2D.Xolotl_to_xolotl: Unable to read the options.  Aborting
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: The material type is not known: ""
test:kernels/2D.Xolotl_to_xolotl: Aborting.
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: *** Warning, This code is deprecated and will be removed in future versions:
test:kernels/2D.Xolotl_to_xolotl: The parameter 'use_legacy_dirichlet_bc' is no longer valid.
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: All Dirichlet boundary conditions are preset by default.
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: Remove said parameter in main to remove this deprecation warning.
test:kernels/2D.Xolotl_to_xolotl: Stack frames: 12
test:kernels/2D.Xolotl_to_xolotl: 0: libMesh::print_trace(std::ostream&)
test:kernels/2D.Xolotl_to_xolotl: 1: void moose::internal::mooseDeprecatedStream<libMesh::BasicOStreamProxy<char, std::char_traits<char> >, char const (&) [62], char const (&) [59], char const (&) [26], std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const (&) [37]>(libMesh::BasicOStreamProxy<char, std::char_traits<char> >&, bool, char const (&) [62], char const (&) [59], char const (&) [26], std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const (&) [37])
test:kernels/2D.Xolotl_to_xolotl: 2: MooseApp::MooseApp(InputParameters)
test:kernels/2D.Xolotl_to_xolotl: 3: coupling_xolotlApp::coupling_xolotlApp(InputParameters)
test:kernels/2D.Xolotl_to_xolotl: 4: coupling_xolotlTestApp::coupling_xolotlTestApp(InputParameters)
test:kernels/2D.Xolotl_to_xolotl: 5: /home/kongf/workhome/rod/coupling_xolotl/test/lib/libcoupling_xolotl_test-opt.so.0(+0xbfd4) [0x7f67b21b3fd4]
test:kernels/2D.Xolotl_to_xolotl: 6: std::shared_ptr<MooseApp> buildApp<coupling_xolotlTestApp>(InputParameters const&)
test:kernels/2D.Xolotl_to_xolotl: 7: AppFactory::createShared(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, InputParameters, int)
test:kernels/2D.Xolotl_to_xolotl: 8: AppFactory::createAppShared(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, char**, int)
test:kernels/2D.Xolotl_to_xolotl: 9: /home/kongf/workhome/rod/coupling_xolotl/coupling_xolotl-opt() [0x403d6f]
test:kernels/2D.Xolotl_to_xolotl: 10: __libc_start_main
test:kernels/2D.Xolotl_to_xolotl: 11: /home/kongf/workhome/rod/coupling_xolotl/coupling_xolotl-opt() [0x403fce]
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: Starting Xolotl Plasma-Surface Interactions Simulator
test:kernels/2D.Xolotl_to_xolotl: Wed Jun 23 15:48:32 2021
test:kernels/2D.Xolotl_to_xolotl: Options: unable to open parameter file: /home/kongf/workhome/rod/coupling_xolotl/test/tests/kernels/2D/./param_x2x_2D_noCnoR.txt
test:kernels/2D.Xolotl_to_xolotl: Unable to read the options.  Aborting
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: The material type is not known: ""
test:kernels/2D.Xolotl_to_xolotl: Aborting.
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: 
test:kernels/2D.Xolotl_to_xolotl: Exit Code: -11
test:kernels/2D.Xolotl_to_xolotl: ################################################################################
test:kernels/2D.Xolotl_to_xolotl: Tester failed, reason: CRASH
test:kernels/2D.Xolotl_to_xolotl: 
```


I also changed makefile to not take HDF5_ROOT since we have hdf5 on our machine, and we can use that directly.