### PR TITLE
Update MOOSE submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,7 @@ python/peacock/tests/postprocessor_tab/TestPostprocessorPluginManager_test_scrip
 !python/peacock/icons/**/*.*
 !python/peacock/tests/**/input/*.*
 peacock_tmp_diff.exo
+
+# Generated resource files
+coupling_xolotl.yaml
+unit/coupling_xolotl-unit.yaml

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a [MOOSE](https://mooseframework.inl.gov/getting_started/index.html) app
 
 Here is how to install this application:
 
-First setup a conda environment following the steps from [here](https://mooseframework.inl.gov/getting_started/installation/conda.html); install boost with `mamba install boost`.
+First setup a conda environment following the steps from [here](https://mooseframework.inl.gov/getting_started/installation/conda.html); install boost with `mamba install boost=1.78.0`.
 
 Then get the code:
 

--- a/include/base/coupling_xolotlApp.h
+++ b/include/base/coupling_xolotlApp.h
@@ -34,8 +34,8 @@ public:
 	static void registerAll(Factory &f, ActionFactory &af, Syntax &s);
 
 	// For restart capabilities
-	std::shared_ptr<Backup> backup();
-	void restore(std::shared_ptr<Backup> backup, bool for_restart = false);
+	virtual void preBackup() override;
+	virtual void postRestore(bool for_restart = false) override;
 
 private:
 	std::shared_ptr<XolotlInterface> _interface;

--- a/src/base/coupling_xolotlApp.C
+++ b/src/base/coupling_xolotlApp.C
@@ -49,7 +49,7 @@ void coupling_xolotlApp::registerApps() {
 	registerApp (coupling_xolotlApp);
 }
 
-std::shared_ptr<Backup> coupling_xolotlApp::backup() {
+void coupling_xolotlApp::preBackup() {
 	if (_is_xolotl_app) {
 		// Get the state from Xolotl
 		mooseAssert(_executioner, "Executioner is nullptr");
@@ -57,16 +57,9 @@ std::shared_ptr<Backup> coupling_xolotlApp::backup() {
 				(XolotlProblem&) _executioner->feProblem();
 		xolotl_problem.saveState();
 	}
-
-	// Back it up
-	return MooseApp::backup();
 }
 
-void coupling_xolotlApp::restore(std::shared_ptr<Backup> backup,
-		bool for_restart) {
-	// Restore the state
-	MooseApp::restore(backup, for_restart);
-
+void coupling_xolotlApp::postRestore(bool /*for_restart*/) {
 	if (_is_xolotl_app) {
 		// Set it in Xolotl
 		mooseAssert(_executioner, "Executioner is nullptr");


### PR DESCRIPTION
Hi @sblondel! 👋🏻 

I was asked to update the MOOSE submodule for this application by an INL collaborator, since there was a major PETSc update (to 3.19.3) and a recent change to the MOOSE backup/restore APIs near the end of the FY.  I've made the relevant necessary changes to `coupled_xolotl` to get things building and passing testing on my Apple Silicon workstation. A couple things to note here beyond the change to `coupled_zolotlApp.C/.h`:

- At least on my machine, the version of boost required to get everything building successfully was `1.78.0`, and I've updated the README to reflect this. Just in case your experience with the conda-provided boost differed, I thought I should discuss it here. My experience with the other versions were as follows:
   - Version `1.80.0` caused an error coming from xolotl (`Log.cpp:4`): 
      ```
      In file included from /Users/user/projects/coupling_xolotl/xolotl/xolotl/util/src/Log.cpp:4:
      In file included from /Users/user/mambaforge3/envs/moose/include/boost/log/attributes.hpp:21:
      In file included from /Users/user/mambaforge3/envs/moose/include/boost/log/attributes/clock.hpp:20:
      In file included from /Users/user/mambaforge3/envs/moose/include/boost/log/attributes/attribute_value.hpp:18:
      In file included from /Users/user/mambaforge3/envs/moose/include/boost/type_index.hpp:29:
      In file included from /Users/user/mambaforge3/envs/moose/include/boost/type_index/stl_type_index.hpp:47:
      /Users/user/mambaforge3/envs/moose/include/boost/container_hash/hash.hpp:132:33: error: no template named 'unary_function' in namespace 'std'; did you mean '__unary_function'?
              struct hash_base : std::unary_function<T, std::size_t> {};
                                 ~~~~~^
      /Users/user/mambaforge3/envs/moose/bin/../include/c++/v1/__functional/unary_function.h:46:1: note: '__unary_function' declared here
      using __unary_function = __unary_function_keep_layout_base<_Arg, _Result>;
      ^
      1 error generated.
      ```
   - Version `1.82.0` was detected by Cmake, but then an error was generated for missing dependencies:
      ```
      CMake Error at /Users/user/mambaforge3/envs/moose/share/cmake-3.25/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
        Could NOT find Boost (missing: log_setup log program_options) (found
        version "1.82.0")
      Call Stack (most recent call first):
        /Users/user/mambaforge3/envs/moose/share/cmake-3.25/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
        /Users/user/mambaforge3/envs/moose/share/cmake-3.25/Modules/FindBoost.cmake:2376 (find_package_handle_standard_args)
        CMakeLists.txt:32 (find_package)
        ```
- I updated the `.gitignore` file to ignore new `.yaml` resource files that are generated during MOOSE builds. 

Please let me know if you have questions, concerns, or want me to make further adjustments. Thanks!

CC: @amjokisaari @sapitts